### PR TITLE
feat: allow ybase build to include custom setup scripts

### DIFF
--- a/ybase/.gitignore
+++ b/ybase/.gitignore
@@ -1,0 +1,1 @@
+custom-scripts

--- a/ybase/README.md
+++ b/ybase/README.md
@@ -1,3 +1,3 @@
 # ybase Docker Image
-The **ybase* container image is a Docker image containing the bundled SAP Commerce installation 
+The **ybase** container image is a Docker image containing the bundled SAP Commerce installation 
 plus additional software your final container need to work properly. 

--- a/ybase/build_img.sh
+++ b/ybase/build_img.sh
@@ -17,6 +17,7 @@ function bundle_installation() {
   echo "Unpacking Hybris bundle ${COMMERCE_BUNDLE_ZIPFILE}"
   unzip $COMMERCE_BUNDLE_ZIPFILE "hybris/*" -d $BASEDIR/target/
   cp -r $BASEDIR/setup-bin $BASEDIR/target/
+  cp -r $BASEDIR/custom-scripts $BASEDIR/target/
 }
 
 function build_base_image() {

--- a/ybase/custom-scripts/01_software_dependencies.sh.template
+++ b/ybase/custom-scripts/01_software_dependencies.sh.template
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+## Place here any custom installation instructions you may need to run your project
+
+## For example:
+# apt-get update && apt-get install --no-install-recommends -y curl gnupg2 lsof wget nano vim
+#
+# curl -sL https://deb.nodesource.com/setup_10.x | bash - &&
+#   apt-get install -y nodejs
+#
+# rm -rf /var/lib/apt/lists/*

--- a/ybase/setup-bin/install.sh
+++ b/ybase/setup-bin/install.sh
@@ -1,4 +1,32 @@
-#!/bin/bash
+#!/bin/bash -e
 
-#TODO: should contain defaut Hybrsis bundle installation tasks, plus custom hooks for additional software
+CUSTOM_SCRIPTS_DIR=${CUSTOM_SCRIPTS_DIR:-/opt/custom-scripts}
+
+function run_custom_scripts() {
+  echo "Looking for custom setup scripts..."
+  ls -l $CUSTOM_SCRIPTS_DIR | grep -e "^.*\.sh$"
+
+  if [[ "$?" = 0 ]]; then
+    chmod +x $CUSTOM_SCRIPTS_DIR/*.sh
+    for file in $CUSTOM_SCRIPTS_DIR/*.sh; do
+
+      if [[ -f "$file" && -x "$file" ]]; then
+        echo "Executing custom setup script: $file"
+
+        bash $file
+
+        if [[ "$?" = 0 ]]; then
+          echo "Done instaling $file."
+        else
+          echo "Failed to execute $file"
+          return 1
+        fi
+      fi
+    done
+  else
+    echo "no custom install script found."
+  fi
+}
+
+run_custom_scripts
 echo "Install done."


### PR DESCRIPTION
When building the ybase container we want to allow users to include
custom setup bash script in order to install dependencies needed for
their projects.

Known issues: still need to include documentation for this new feature.
It will be addressed in a subsequent issue.

Fixes #12
See also #17