### PR TITLE
feat: add hadolint step to CI build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,4 @@ jobs:
         # Install hadolint
         wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 && chmod +x hadolint
         # Run linting
-        ./hadolint test/do_lint.sh
+        # ./hadolint test/do_lint.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,8 @@ jobs:
       run: |
         # Install hadolint
         wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &> /dev/null && chmod +x hadolint
-        PATH=$PATH:$PWD/hadolint
+        export PATH=$PATH:$PWD/hadolint
+        echo $PATH
         # Run linting
         test/do_lint.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,9 @@ jobs:
     - name: Dockerfile linting
       run: |
         # Install hadolint
-        wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &> /dev/null && chmod +x hadolint
-        export PATH=$PATH:$PWD/hadolint
+        mkdir ci-bin/
+        wget -O ci-bin/hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &> /dev/null && chmod +x ci-bin/hadolint
+        export PATH=$PATH:$PWD/ci-bin
         echo $PATH
         # Run linting
         test/do_lint.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Dockerfile linting
       run: |
         # Install hadolint
-        wget -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &&\
-        chmod +x /bin/hadolint
+        wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &&\
+          chmod +x hadolint
         # Run linting
-        hadolint test/do_lint.sh
+        ./hadolint test/do_lint.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,6 @@ jobs:
     - name: Run all unit tests
       run: test/all_tests.sh
     - name: Dockerfile linting
-      uses: brpaz/hadolint-action@master
-      with: 
-        dockerfile
       run: |
         # Install hadolint
         wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 && chmod +x hadolint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Dockerfile linting
       run: |
         # Install hadolint
-        wget -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &> /dev/null && chmod +x /bin/hadolint
+        wget -O /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &> /dev/null && chmod +x /usr/local/bin/hadolint
         # Run linting
-        # ./hadolint test/do_lint.sh
+        # test/do_lint.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     - name: Dockerfile linting
       run: |
         # Install hadolint
-        wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &> /dev/null && chmod +x hadolint
+        wget -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &> /dev/null && chmod +x /bin/hadolint
         # Run linting
         # ./hadolint test/do_lint.sh
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,3 +12,10 @@ jobs:
       name: Checkout code
     - name: Run all unit tests
       run: test/all_tests.sh
+    - name: Dockerfile linting
+      run: |
+        # Install hadolint
+        wget -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &&\
+        chmod +x /bin/hadolint
+        # Run linting
+        hadolint test/do_lint.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
     - name: Dockerfile linting
       run: |
         # Install hadolint
-        wget -O /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &> /dev/null && chmod +x /usr/local/bin/hadolint
+        wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &> /dev/null && chmod +x hadolint
+        PATH=$PATH:$PWD/hadolint
         # Run linting
-        # test/do_lint.sh
+        test/do_lint.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,11 @@ jobs:
     - name: Run all unit tests
       run: test/all_tests.sh
     - name: Dockerfile linting
+      uses: brpaz/hadolint-action@master
+      with: 
+        dockerfile
       run: |
         # Install hadolint
-        wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &&\
-          chmod +x hadolint
+        wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 && chmod +x hadolint
         # Run linting
         ./hadolint test/do_lint.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,6 @@ jobs:
     - name: Dockerfile linting
       run: |
         # Install hadolint
-        wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 && chmod +x hadolint
+        wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &> /dev/null && chmod +x hadolint
         # Run linting
         # ./hadolint test/do_lint.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
         mkdir ci-bin/
         wget -O ci-bin/hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.5/hadolint-Linux-x86_64 &> /dev/null && chmod +x ci-bin/hadolint
         export PATH=$PATH:$PWD/ci-bin
-        echo $PATH
         # Run linting
         test/do_lint.sh
 

--- a/test/do_lint.sh
+++ b/test/do_lint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+### Run linting for all Dockerfiles defined in dockerfiles.list
+
+BASEDIR="$(dirname "$0")"
+
+dofiles=$(
+while read line
+do 
+  echo -n " ${line}"
+done < $BASEDIR/dockerfiles.list)
+
+hadolint ${dofiles}

--- a/test/dockerfiles.list
+++ b/test/dockerfiles.list
@@ -1,0 +1,2 @@
+Dockerfile
+ybase/Dockerfile


### PR DESCRIPTION
Introducing a new linting step for Dockerfiles with `hadolint` command.
All dockerfiles created in the project should now be listed in
`test/dockerfiles.list` file, the linting command will then execute the
linting for all the provided Dockerfiles.

Fixes #21